### PR TITLE
Add PHP 7.4 version test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 /coverage/
 /vendor/
 /.idea/
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,6 @@ matrix:
     - php: '7.1'
     - php: '7.2'
     - php: '7.3'
+    - php: '7.4'
     - php: nightly
       env: setup=nightly


### PR DESCRIPTION
# Changed log
- Add `php-7.4` version test during Travis CI build.
- The `.phpunit.result.cache` is generated by `PHPUnit` test execution and it should not be under Git version control. Let this cached file on `.gitignore` file.