### PR TITLE
Add support for Carbon 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "simple-cli/simple-cli": "^1.1",
-        "nesbot/carbon": "^2.20"
+        "nesbot/carbon": "^2.20 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5 || ^8.2"

--- a/src/Carbon/Types/Generator.php
+++ b/src/Carbon/Types/Generator.php
@@ -3,6 +3,7 @@
 namespace Carbon\Types;
 
 use Carbon\Carbon;
+use Carbon\FactoryImmutable;
 use Closure;
 use ReflectionClass;
 use ReflectionException;
@@ -51,11 +52,17 @@ class Generator
             $this->runBoot($boot);
         }
 
-        $c = new ReflectionClass(Carbon::now());
-        $macros = $c->getProperty('globalMacros');
-        $macros->setAccessible(true);
+        if (method_exists(FactoryImmutable::class, 'getDefaultInstance')) {
+            // Carbon 3
+            return FactoryImmutable::getDefaultInstance()->getSettings()['macros'] ?? [];
+        } else {
+            // Carbon 2
+            $c = new ReflectionClass(Carbon::now());
+            $macros = $c->getProperty('globalMacros');
+            $macros->setAccessible(true);
 
-        return $macros->getValue();
+            return $macros->getValue();
+        }
     }
 
     /**


### PR DESCRIPTION
This PR adds support for Carbon 3, while maintaining the existing support for Carbon 2.

From what I could see by comparing the v2 Carbon\PHPStan\MacroScanner and the v3 Carbon\PHPStan\MacroExtension classes, I think this FactoryImmutable approach is what has replaced the globalMacros variable - I hope I haven't completely misunderstood, but I'm mainly going off test results. Beforehand, tests failed for Carbon 3, but they now pass for both Carbon 2/3 on this branch.

This relates to https://github.com/kylekatarnls/carbon-cli/issues/7

Thanks for all your work!