### PR TITLE
Start moving CI from Travis to GitHub Actions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,7 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - gh-pages
+      - "**"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,7 +57,7 @@ jobs:
         run: vendor/bin/phpunit --coverage-clover=coverage.xml --coverage-text --log-junit test-results.xml
 
       - name: Upload Test Results
-        uses: action/upload-artifact@v3
+        uses: actions/upload-artifact@v3
         with:
           name: phpunit-test-results
           path: test-results.xml

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,3 +53,6 @@ jobs:
           chmod +x ./cc-test-reporter
           ./cc-test-reporter before-build
 
+      - name: Run Tests
+        run: vendor/bin/phpunit --coverage-clover=coverage.xml --coverage-text --log-junit junit.xml
+

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,6 +11,9 @@ jobs:
     name: PHP Test Matrix
     runs-on: ubuntu-latest
 
+    env:
+      CC_TEST_REPORTER_ID: a706e45a0731ff71fe03470fefba2e1469a856018f131d0aee0be3f26ec4fc16
+
     strategy:
       matrix:
         php-version: [7.1, 7.2, 7.3]
@@ -43,4 +46,10 @@ jobs:
           elif [ "${{ matrix.setup }}" == "basic" ]; then
             composer update --prefer-dist --prefer-stable --no-interaction --no-suggest;
           fi
+
+      - name: Download Code Climate Test Reporter
+        run: |
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+          ./cc-test-reporter before-build
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,7 +54,13 @@ jobs:
           ./cc-test-reporter before-build
 
       - name: Run Tests
-        run: vendor/bin/phpunit --coverage-clover=coverage.xml --coverage-text --log-junit junit.xml
+        run: vendor/bin/phpunit --coverage-clover=coverage.xml --coverage-text --log-junit test-results.xml
+
+      - name: Upload Test Results
+        uses: action/upload-artifact@v3
+        with:
+          name: phpunit-test-results
+          path: test-results.xml
 
       - name: Upload Coverage to Codecov
         if: success()

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -63,5 +63,5 @@ jobs:
       - name: Finalize Code Climate Report
         run: |
           cp coverage.xml clover.xml
-          EXIT_CODE=$([ ${{ success() }} ] && echo 0 || echo 1)
+          EXIT_CODE=$([ "${{ steps.test.outcome }}" == "success" ] && echo 0 || echo 1)
           ./cc-test-reporter after-build --coverage-input-type clover --exit-code $EXIT_CODE

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,3 +5,17 @@ on:
     branches:
       - gh-pages
       - "**"
+
+jobs:
+  test:
+    name: PHP Test Matrix
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-version: [7.1, 7.2, 7.3]
+        setup: [basic]
+        include:
+          - php-version: nightly
+            setup: nightly
+      fail-fast: false

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -56,3 +56,12 @@ jobs:
       - name: Run Tests
         run: vendor/bin/phpunit --coverage-clover=coverage.xml --coverage-text --log-junit junit.xml
 
+      - name: Upload Coverage to Codecov
+        if: success()
+        run: bash <(curl -s https://codecov.io/bash)
+
+      - name: Finalize Code Climate Report
+        run: |
+          cp coverage.xml clover.xml
+          EXIT_CODE=$([ ${{ success() }} ] && echo 0 || echo 1)
+          ./cc-test-reporter after-build --coverage-input-type clover --exit-code $EXIT_CODE

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,10 +57,11 @@ jobs:
         run: vendor/bin/phpunit --coverage-clover=coverage.xml --coverage-text --log-junit test-results.xml
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: phpunit-test-results
+          name: "${{ matrix.php-version }}-phpunit-results"
           path: test-results.xml
+        if: ${{ always() }}
 
       - name: Upload Coverage to Codecov
         if: success()

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,3 +19,28 @@ jobs:
           - php-version: nightly
             setup: nightly
       fail-fast: false
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          tools: composer
+
+      - name: Cache/Restore Composer
+        uses: actions/cache@v3
+        with:
+          path: ~/.composer/cache
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+
+      - name: Install Dependencies
+        run: |
+          if [ "${{ matrix.setup }}" == "nightly" ]; then
+            composer update --prefer-dist --no-interaction --no-suggest --ignore-platform-reqs;
+          elif [ "${{ matrix.setup }}" == "basic" ]; then
+            composer update --prefer-dist --prefer-stable --no-interaction --no-suggest;
+          fi
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,4 @@ after_script:
 
 env:
   global:
-    - setup=basic
     - CC_TEST_REPORTER_ID=a706e45a0731ff71fe03470fefba2e1469a856018f131d0aee0be3f26ec4fc16
-
-matrix:
-  include:
-    - php: '7.1'
-    - php: '7.2'
-    - php: '7.3'
-    - php: nightly
-      env: setup=nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: php
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
-
-after_script:
-  - cp coverage.xml clover.xml
-  - ./cc-test-reporter after-build --coverage-input-type clover --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,5 @@
 language: php
 
-cache:
-  apt: true
-  directories:
-    - $HOME/.composer/cache
-
-sudo: false
-
-install:
-  - if [[ $setup = 'nightly' ]]; then travis_retry composer update --prefer-dist --no-interaction --no-suggest --ignore-platform-reqs; fi
-  - if [[ $setup = 'basic' ]]; then travis_retry composer update --prefer-dist --prefer-stable --no-interaction --no-suggest; fi
-
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: php
 
-script:
-  - vendor/bin/phpunit --coverage-clover=coverage.xml --coverage-text
-
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,6 @@ env:
     - setup=basic
     - CC_TEST_REPORTER_ID=a706e45a0731ff71fe03470fefba2e1469a856018f131d0aee0be3f26ec4fc16
 
-branches:
-  only:
-    - gh-pages
-    - /.*/
-
 matrix:
   include:
     - php: '7.1'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: php
 
-before_script:
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - ./cc-test-reporter before-build
-
 script:
   - vendor/bin/phpunit --coverage-clover=coverage.xml --coverage-text
 
@@ -14,7 +9,3 @@ after_success:
 after_script:
   - cp coverage.xml clover.xml
   - ./cc-test-reporter after-build --coverage-input-type clover --exit-code $TRAVIS_TEST_RESULT
-
-env:
-  global:
-    - CC_TEST_REPORTER_ID=a706e45a0731ff71fe03470fefba2e1469a856018f131d0aee0be3f26ec4fc16


### PR DESCRIPTION
@kylekatarnls mentioned on https://github.com/kylekatarnls/carbon-cli/issues/7 that tests would need to migrate from Travis to GitHub Actions - this PR hopefully does most of the work for that, to make life easier!

I can't claim to be a GitHub actions expert, and I think it probably needs a Code Climate token or something in a secret, but I figured this might be a helpful starting point - if not, I'll not be offended if you want to decline it and start again!